### PR TITLE
Add support for sieve filtering plugin

### DIFF
--- a/docs/guides.rst
+++ b/docs/guides.rst
@@ -19,7 +19,7 @@ by setting the following configuration:
     postfix_local_maincf: |
       home_mailbox = Maildir/
 
-This example will store the mails in the ``Maildir/`` folder within the users
+This example will store the mails in the ``Maildir/`` folder within the user's
 home directory. You can make dovecot looking for this maildir by setting::
 
     dovecot_mail_location: 'maildir:~/Maildir'
@@ -30,3 +30,51 @@ advanced values. Check the dovecot `mail_location`_ documentation for more
 examples.
 
 .. _mail_location: http://wiki2.dovecot.org/MailLocation/
+
+
+Enable server-side mail filtering with sieve
+--------------------------------------------
+
+`Sieve`_ is a programming language to define mail filtering rules. The
+rules are stored as text files on the mail server and can be managed by
+a client via `ManageSieve`_ network protocol. Dovecot provides sieve support
+via Pigeonhole sieve interpreter.
+
+.. _Sieve: http://wiki2.dovecot.org/Pigeonhole/Sieve/
+.. _ManageSieve: http://wiki2.dovecot.org/Pigeonhole/ManageSieve/
+
+All you have to do to enable (Manage)Sieve in your Dovecot role is to add
+it to the ``dovecot_protocols`` list::
+
+    dovecot_protocols: [ 'imap', 'imaps', 'managesieve' ]
+
+The ManageSieve protocol listens on port 4190 and requires STARTTLS for
+authentication. You can restrict access to this port by explicitly listing
+the networks or hosts which are allowed to connect::
+
+    dovecot_allow_managesieve: [ '192.168.1.0/24' ]
+
+The sieve filter rules are applied before delivering the mail to the user's
+mailbox. There are various ways for mail delivery but only a few of them
+respect the sieve filters. By default DebOps would simply use postfix to
+write the mail. However, postfix doesn't know anything about sieve.
+Therefore you have to manually add the following configuration to each
+user's ``~/.forward`` file, to hook-in the Dovecot LDA (local delivery
+agent)::
+
+    | "/usr/lib/dovecot/dovecot-lda"
+
+The Dovecot LDA would then deliver the mail after enquiring the sieve
+files.
+
+Another possibility would be to tell Postfix to forward the mail to the
+Dovecot LMTP (local mail transfer protocol) service which also supports
+sieve filtering. Unfortunately support for this hasn't been added to
+the corresponding DebOps rules yet.
+
+By default the Dovecot sieve plugin will store the user defined rules as
+plain text files in the ``~/sieve/`` folder. They can be managed directly
+via file system, by a mail client which supports the ManageSieve protocol
+or alternatively by a tool like `sieve-connect`_.
+
+.. _sieve-connect: https://github.com/philpennock/sieve-connect/

--- a/templates/etc/dovecot/local.conf/ansible.j2
+++ b/templates/etc/dovecot/local.conf/ansible.j2
@@ -4,6 +4,7 @@
   'auth',
   'mailbox',
   'tls',
+  'delivery',
   'custom' ] %}
 {% for part in dovecot_tpl_localconf_parts %}
 {% include part + '.j2' %}

--- a/templates/etc/dovecot/local.conf/delivery.j2
+++ b/templates/etc/dovecot/local.conf/delivery.j2
@@ -1,0 +1,7 @@
+{% if 'managesieve' in dovecot_protocols %}
+# Mail delivery
+protocol lda {
+    mail_plugins = $mail_plugins sieve
+}
+{% endif %}
+


### PR DESCRIPTION
As mentioned in #6, mail filtering via sieve, was not yet working. These commits will add a missing part of the configuration and some documentation about how to enable sieve filtering. 