### PR TITLE
only active deny users config if 'deny' in dovecot_user_accounts

### DIFF
--- a/templates/etc/dovecot/conf.d/10-auth.conf.j2
+++ b/templates/etc/dovecot/conf.d/10-auth.conf.j2
@@ -25,7 +25,10 @@ auth_mechanisms = {{ " ".join(dovecot_auth_mechanisms) }}
 ## Password and user databases
 ##
 
-{% if dovecot_deny_users is defined and dovecot_deny_users %}
+{% if 'deny' not in dovecot_user_accounts %}
+# 'deny' not in dovecot_user_accounts: {{ dovecot_user_accounts }}
+# dovecot_deny_users: {{ dovecot_deny_users }}
+{% elif dovecot_deny_users is defined and dovecot_deny_users %}
 !include auth-deny.conf.ext
 {% endif %}
 {% if 'system' in dovecot_user_accounts %}


### PR DESCRIPTION
The task for generating the dovecot config currently checks for
'{{ "auth-deny.conf.ext" if "deny" in dovecot_user_accounts else [] }}'.
The template, however, does not perform the same check. Hence the task
does not update "auth-deny.conf.ext".  The consequence is that the
default file will be used which references /etc/dovecot/deny-users
instead of dovecot.deny.  The former, however, does not exist which
makes dovecot complain.

This change applies the same deny checking logic used in the task to the
template.  The auth-deny config should thus only be included if we
indeed manage deny users.