### PR TITLE
Add possibility to disable firewall

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -303,3 +303,9 @@ dovecot_postfix_transport: 'lmtp:unix:private/dovecot-lmtp'
 # Dovecot custom configuration added at the end of ``/etc/dovecot/local.conf``
 # in a text block format
 dovecot_custom_localconf: False
+
+# .. envvar:: dovecot_firewall
+#
+# Choose to use firewall with debops.ferm to drive iptables or not.
+#
+dovecot_firewall: True

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -2,6 +2,7 @@
 
 dependencies:
   - role: debops.ferm
+    when: (dovecot_firewall is defined and dovecot_firewall)
 
   - role: debops.postfix
     postfix_dependent_maincf:


### PR DESCRIPTION
It is mandatory to use ferm with debops.ferm ansible playbook.
This change let`s user choose.

Tested on debian.

Signed-off-by: Cyril Lopez <cylopez@redhat.com>