### PR TITLE
Add trigger to disable dotlock

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -60,6 +60,15 @@ dovecot_deny_users: [ 'root' ]
 dovecot_mail_location: 'mbox:~/mail:INBOX=/var/mail/%u'
 
 
+# .. envvar:: dovecot_mail_dotlock
+#
+# Mailbox Locking. The only standard way to lock an mbox is using a method
+# called ``dotlock``. This means that a file named <mailbox-name>.lock is
+# created in the same directory as the mailbox being locked. `Documentation
+# Location <https://wiki.dovecot.org/MboxLocking>`_
+dovecot_mail_dotlock: True
+
+
 # .. envvar:: dovecot_sql_driver
 #
 # The SQL driver defines which SQL is used. This can be either ``mysql``

--- a/templates/etc/dovecot/conf.d/10-mail.conf.j2
+++ b/templates/etc/dovecot/conf.d/10-mail.conf.j2
@@ -23,3 +23,7 @@ mail_location = {{ dovecot_mail_location }}
 namespace inbox {
   inbox = yes
 }
+{% if dovecot_mail_dotlock is defined and not dovecot_mail_dotlock %}
+dotlock_use_excl = no
+mbox_write_locks = fcntl
+{% endif %}


### PR DESCRIPTION
Dotlock is a feature to write a file XXX.lock. It create an issue when
on debian 8 due to right.

Tested on debian 8.

Signed-off-by: Cyril Lopez <cylopez@redhat.com>