### PR TITLE
Fix error when dovecot_firewall is False

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -118,6 +118,7 @@
     group: 'adm'
     mode: '0644'
   notify: [ 'Restart ferm' ]
+  when: (dovecot_firewall is defined and dovecot_firewall)
 
 - name: Create private directory to store passwdfile 
   file: 


### PR DESCRIPTION
Don't update firewall files when dovecot_firewall is False.
Otherwise the following error arises:

```
TASK [debops.dovecot : Configure firewall for Dovecot] *
fatal: [mail]: FAILED! => {"changed": true, "failed": true, "msg": "Destination directory /etc/ferm/filter-input.d does not exist"}
```