### PR TITLE
update tls, 10-ssl.conf

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -228,8 +228,12 @@ dovecot_ssl_protocols: '!SSLv2 !SSLv3'
 # .. envvar:: dovecot_ssl_cipher_list
 #
 # SSL ciphers to use
-dovecot_ssl_cipher_list: 'TLSv1+HIGH:!SSLv2:!EXPORT:!RC4:!aNULL:!eNULL:!3DES:@STRENGTH'
+dovecot_ssl_cipher_list: '{{ dovecot_ssl_cipher_list_default }}'
 
+dovecot_ssl_cipher_list_default: 'TLSv1+HIGH:!SSLv2:!EXPORT:!RC4:!aNULL:!eNULL:!3DES:@STRENGTH'
+
+# https://bettercrypto.org/
+dovecot_ssl_cipher_list_better_cypto: 'EDH+CAMELLIA:EDH+aRSA:EECDH+aRSA+AESGCM:EECDH+aRSA+SHA256:EECDH:+CAMELLIA128:+AES128:+SSLv3:!aNULL:!eNULL:!LOW:!3DES:!MD5:!EXP:!PSK:!DSS:!RC4:!SEED:!IDEA:!ECDSA:kEDH:CAMELLIA128-SHA:AES128-SHA'
 
 # --------------------------------
 #   Dovecot custom configuration

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -220,6 +220,10 @@ dovecot_pki_key: 'default.key'
 # <http://wiki2.dovecot.org/SSL/DovecotConfiguration>`_
 dovecot_ssl_required: True
 
+# .. envvar:: dovecot_ssl_protocols
+#
+# SSL ciphers to use
+dovecot_ssl_protocols: '!SSLv2 !SSLv3'
 
 # .. envvar:: dovecot_ssl_cipher_list
 #

--- a/templates/etc/dovecot/conf.d/10-ssl.conf.j2
+++ b/templates/etc/dovecot/conf.d/10-ssl.conf.j2
@@ -22,7 +22,7 @@ ssl = yes
 {% set dovecot_tpl_tls_key_file     = dovecot_pki_path + "/" + dovecot_pki_realm + "/" + dovecot_pki_key %}
 ssl_cert    = <{{ dovecot_tpl_tls_cert_file }}
 ssl_key     = <{{ dovecot_tpl_tls_key_file }}
-ssl_protocols   = !SSLv2 !SSLv3
+ssl_protocols   = {{ dovecot_ssl_protocols }}
 ssl_cipher_list = {{ dovecot_ssl_cipher_list }}
 {% else %}
 ssl = no

--- a/templates/etc/dovecot/conf.d/10-ssl.conf.j2
+++ b/templates/etc/dovecot/conf.d/10-ssl.conf.j2
@@ -18,6 +18,12 @@ ssl = required
 ssl = yes
 {%   endif %}
 
+# Prefer the server's order of ciphers over client's. (Dovecot >=2.2.6 Required)
+ssl_prefer_server_ciphers = yes
+
+# Diffie-Hellman parameters length (Default is 1024, Dovecot >=2.2.7 Required)
+ssl_dh_parameters_length = 2048
+
 {% set dovecot_tpl_tls_cert_file    = dovecot_pki_path + "/" + dovecot_pki_realm + "/" + dovecot_pki_crt %}
 {% set dovecot_tpl_tls_key_file     = dovecot_pki_path + "/" + dovecot_pki_realm + "/" + dovecot_pki_key %}
 ssl_cert    = <{{ dovecot_tpl_tls_cert_file }}


### PR DESCRIPTION
1. Patch adds the possibility to change the  `ssl_protocols`, this is needed in the default installation of dovecot on debian stretch.
Got this error:
`imap-login: Fatal: Invalid ssl_protocols setting: Unknown protocol 'SSLv2'`

Probably change this value to `!SSLv3` by default, don't think there is a debian with SSLv2 still using this script.

2. Patch add bettercrypto.org ssl settings. Currently using old ciphers by default.


ps.
Thanks for the ansible scripts :D